### PR TITLE
Add normalize.css to head

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/guui",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Frontend rendering framework",
     "main": "dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     },
     "homepage": "https://github.com/guardian/guui#readme",
     "dependencies": {
+        "normalize.css": "^7.0.0",
         "react": "^16.2.0",
         "react-dom": "^16.2.0",
         "react-hot-loader": "^4.0.0-beta.18",
@@ -57,6 +58,7 @@
         "rollup-plugin-babel": "^3.0.3",
         "rollup-plugin-commonjs": "^8.3.0",
         "rollup-plugin-node-resolve": "^3.0.2",
+        "rollup-plugin-string": "^2.0.2",
         "simple-progress-webpack-plugin": "^1.0.4",
         "webpack": "^3.8.1",
         "webpack-bundle-analyzer": "^2.9.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/guui",
-    "version": "2.1.0",
+    "version": "2.0.0",
     "description": "Frontend rendering framework",
     "main": "dist/index.js",
     "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@
 import babel from 'rollup-plugin-babel';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import string from 'rollup-plugin-string';
 
 export default {
     input: 'src/app/index.server.js',
@@ -27,5 +28,8 @@ export default {
             browser: false,
         }),
         resolve(),
+        string({
+			include: '**/*.css',
+		}),
     ],
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,6 +20,7 @@ export default {
     plugins: [
         babel({
             externalHelpers: true,
+            exclude: '**/*.css',
         }),
         commonjs({
             module: true,

--- a/src/app/__html.js
+++ b/src/app/__html.js
@@ -1,4 +1,8 @@
 // @flow
+import normalize from 'normalize.css';
+
+console.log( `CSS ----> ${normalize}` );
+
 export default ({
     stylesForHead,
     html,
@@ -10,6 +14,11 @@ export default ({
     <html>
         <head>
             <title>My Universal App</title>
+            <style>
+                body {
+                    margin: 0;
+                }
+            </style>
             ${stylesForHead}
             <script src="/assets/javascript/app.browser.js" async></script>
         </head>

--- a/src/app/__html.js
+++ b/src/app/__html.js
@@ -1,8 +1,6 @@
 // @flow
 import normalize from 'normalize.css';
 
-console.log( `CSS ----> ${normalize}` );
-
 export default ({
     stylesForHead,
     html,
@@ -15,9 +13,7 @@ export default ({
         <head>
             <title>My Universal App</title>
             <style>
-                body {
-                    margin: 0;
-                }
+                ${normalize}
             </style>
             ${stylesForHead}
             <script src="/assets/javascript/app.browser.js" async></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3612,6 +3612,10 @@ normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+normalize.css@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-7.0.0.tgz#abfb1dd82470674e0322b53ceb1aaf412938e4bf"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -4367,6 +4371,12 @@ rollup-plugin-node-resolve@^3.0.2:
     builtin-modules "^1.1.0"
     is-module "^1.0.0"
     resolve "^1.1.6"
+
+rollup-plugin-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-string/-/rollup-plugin-string-2.0.2.tgz#f5323a22cfd738b450cbea62ab6593705eac744b"
+  dependencies:
+    rollup-pluginutils "^1.5.0"
 
 rollup-pluginutils@^1.5.0:
   version "1.5.2"


### PR DESCRIPTION
This PR adds global style resets to the `<head>`.

I'm importing `normalize.css` and in `rollup.config.js` using `rollup-plugin-string` to convert any `.css` import to a string. I'm importing `normalize.css` in `__html.js` and adding the stringified styled to the `<head>`.

**TODO**: The styles inserted into the `<head>` are not minified. It'd be good to minify/remove comments.