### PR TITLE
use types for breakpoints

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -10,7 +10,7 @@ import {
     leftCol,
     wide,
     between,
-import { from, until } from '../styles/functions';
+} from '../styles/functions';
 import TheGuardianLogoSVG from '../../static/inline-svgs/the-guardian-logo.svg';
 
 // .new-header.pillar-scheme--News

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,6 +1,15 @@
 // @flow
 import { styled } from 'styletron-react';
 import { hidden, clearFix } from '../styles/mixins';
+import {
+    until,
+    mobileLandscape,
+    mobileMedium,
+    tablet,
+    desktop,
+    leftCol,
+    wide,
+    between,
 import { from, until } from '../styles/functions';
 import TheGuardianLogoSVG from '../../static/inline-svgs/the-guardian-logo.svg';
 
@@ -9,7 +18,7 @@ const Head = styled('header', {
     'margin-bottom': 0,
     'background-color': '#e9eff1',
     position: 'relative',
-    [from('tablet')]: {
+    [tablet]: {
         display: 'block',
     },
 });
@@ -17,16 +26,17 @@ const Head = styled('header', {
 // .new-header__inner.gs-container
 const Nav = styled('nav', {
     ...clearFix,
-    [from('tablet')]: {
+    [between.mobileMedium.and.desktop]: {},
+    [tablet]: {
         'max-width': '740px',
     },
-    [from('desktop')]: {
+    [desktop]: {
         'max-width': '980px',
     },
-    [from('leftCol')]: {
+    [leftCol]: {
         'max-width': '1140px',
     },
-    [from('wide')]: {
+    [wide]: {
         'max-width': '1300px',
     },
     position: 'relative',
@@ -39,13 +49,13 @@ const HomeLink = styled('a', {
     'margin-bottom': '15px',
     'margin-right': '45px',
     'margin-top': '5px',
-    [from('mobileMedium')]: {
+    [mobileMedium]: {
         'margin-right': '5px',
     },
-    [from('mobileLandscape')]: {
+    [mobileLandscape]: {
         'margin-right': '17px',
     },
-    [from('desktop')]: {
+    [desktop]: {
         'margin-bottom': '-34px',
         'margin-top': '5px',
         position: 'relative',
@@ -93,15 +103,15 @@ const topBarItem = props => {
         },
         ':hover': focusHoverStyles,
         ':focus': focusHoverStyles,
-        [from('tablet')]: {
+        [tablet]: {
             'font-size': '14px',
         },
     };
 
     if (props.isPayingMember || props.isRecentContributor) {
         styles[':nth-child(2)'] = Object.assign({}, styles[':nth-child(2)'], {
-            'padding-left': 0,
-            'margin-left': '20px',
+            paddingLeft: 0,
+            marginLeft: '20px',
         });
     }
 
@@ -122,7 +132,7 @@ const BecomeAMemberLink = styled('a', props => {
         'font-weight': 800,
         padding: 0,
         margin: 0,
-        [until('mobileLandscape')]: {
+        [until.mobileLandscape]: {
             'margin-left': '-10px',
         },
         ':focus': focusHoverStyles,
@@ -177,14 +187,14 @@ const PillarList = styled('ul', props => {
         padding: '0 10px',
         'list-style': 'none',
         'list-style-image': 'none',
-        [from('mobileLandscape')]: {
+        [mobileLandscape]: {
             'padding-left': '20px',
         },
     };
 
     if (props.isHeaderOpen) {
         styles = Object.assign({}, styles, {
-            [from('desktop')]: {
+            [desktop]: {
                 'z-index': 1070,
             },
         });
@@ -192,7 +202,7 @@ const PillarList = styled('ul', props => {
 
     if (props.isHeaderSlim) {
         styles = Object.assign({}, styles, {
-            [from('tablet')]: {
+            [tablet]: {
                 display: 'none',
             },
         });
@@ -205,7 +215,7 @@ const PillarList = styled('ul', props => {
 const PillarListItem = styled('li', {
     display: 'block',
     float: 'left',
-    [from('desktop')]: {
+    [desktop]: {
         width: '118px',
     },
 });
@@ -240,7 +250,7 @@ const PillarListItemLink = styled('a', props => {
         padding: '0 4px',
         position: 'relative',
         overflow: 'hidden',
-        [from('tablet')]: {
+        [tablet]: {
             'font-size': '22px',
             height: '42px',
             'padding-right': '20px',
@@ -334,8 +344,8 @@ export default () => {
                 </TopBar>
                 <PillarList>
                     {pillars.map((pillar, i) => (
-                        <PillarListItem key={i}>
-                            <PillarListItemLink index={i} key={i}>
+                        <PillarListItem key={pillar.label}>
+                            <PillarListItemLink index={i} key={pillar.label}>
                                 {pillar.label}
                             </PillarListItemLink>
                         </PillarListItem>

--- a/src/styles/functions.js
+++ b/src/styles/functions.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint-disable no-underscore-dangle */
 
-// underscored names to avoid export name class
+// underscored names to avoid clashing with the `from` shorthand exports
 const _mobile = 320;
 const _mobileMedium = 360;
 const _mobileLandscape = 480;

--- a/src/styles/functions.js
+++ b/src/styles/functions.js
@@ -11,10 +11,12 @@ const _desktop = 980;
 const _leftCol = 1140;
 const _wide = 1300;
 
-const minWidth = from => `@media (min-width: ${`${from}px`})`;
+const minWidth = (from: number): string => `@media (min-width: ${`${from}px`})`;
 
-const maxWidth = until => `@media (max-width: ${`${until - 1}px`})`;
-const minWidthMaxWidth = (from, until) =>
+const maxWidth = (until: number): string =>
+    `@media (max-width: ${`${until - 1}px`})`;
+
+const minWidthMaxWidth = (from: number, until: number): string =>
     `@media (min-width: ${`${from}px`}) and (max-width: ${`${until - 1}px`})`;
 
 // e.g. from.*

--- a/src/styles/functions.js
+++ b/src/styles/functions.js
@@ -1,29 +1,112 @@
 // @flow
-const breakpoints = {
-    mobile: 320,
-    mobileMedium: 360,
-    mobileLandscape: 480,
-    phablet: 660,
-    tablet: 740,
-    desktop: 980,
-    leftCol: 1140,
-    wide: 1300,
+/* eslint-disable no-underscore-dangle */
+
+// underscored names to avoid export name class
+const _mobile = 320;
+const _mobileMedium = 360;
+const _mobileLandscape = 480;
+const _phablet = 660;
+const _tablet = 740;
+const _desktop = 980;
+const _leftCol = 1140;
+const _wide = 1300;
+
+const minWidth = from => `@media (min-width: ${`${from}px`})`;
+
+const maxWidth = until => `@media (max-width: ${`${until - 1}px`})`;
+const minWidthMaxWidth = (from, until) =>
+    `@media (min-width: ${`${from}px`}) and (max-width: ${`${until - 1}px`})`;
+
+// e.g. from.*
+export const from = {
+    mobile: minWidth(_mobile),
+    mobileMedium: minWidth(_mobileMedium),
+    mobileLandscape: minWidth(_mobileLandscape),
+    phablet: minWidth(_phablet),
+    tablet: minWidth(_tablet),
+    desktop: minWidth(_desktop),
+    leftCol: minWidth(_leftCol),
+    wide: minWidth(_wide),
 };
 
-const getSizeFromBreakpoint = breakpoint => {
-    if (breakpoints[breakpoint]) {
-        return breakpoints[breakpoint];
-    }
-    return '0';
-};
-const getMinWidth = breakpoint =>
-    `(min-width: ${`${getSizeFromBreakpoint(breakpoint)}px`})`;
-const getMaxWidth = breakpoint =>
-    `(max-width: ${`${getSizeFromBreakpoint(breakpoint) - 1}px`})`;
+// shorthands for from.*
+export const {
+    mobile,
+    mobileMedium,
+    mobileLandscape,
+    phablet,
+    tablet,
+    desktop,
+    leftCol,
+    wide,
+} = from;
 
-export const from = breakpoint => `@media ${getMinWidth(breakpoint)}`;
-export const until = breakpoint => `@media ${getMaxWidth(breakpoint)}`;
-export const between = (lowerBreakpoint, upperBreakpoint) =>
-    `@media ${getMinWidth(lowerBreakpoint)} and ${getMaxWidth(
-        upperBreakpoint,
-    )}`;
+// e.g. until.*
+export const until = {
+    mobile: maxWidth(_mobile),
+    mobileMedium: maxWidth(_mobileMedium),
+    mobileLandscape: maxWidth(_mobileLandscape),
+    phablet: maxWidth(_phablet),
+    tablet: maxWidth(_tablet),
+    desktop: maxWidth(_desktop),
+    leftCol: maxWidth(_leftCol),
+    wide: maxWidth(_wide),
+};
+
+// e.g. between.*.and.*
+export const between = {
+    mobile: {
+        and: {
+            mobileMedium: minWidthMaxWidth(_mobile, _mobileMedium),
+            mobileLandscape: minWidthMaxWidth(_mobile, _mobileLandscape),
+            phablet: minWidthMaxWidth(_mobile, _phablet),
+            tablet: minWidthMaxWidth(_mobile, _tablet),
+            desktop: minWidthMaxWidth(_mobile, _desktop),
+            leftCol: minWidthMaxWidth(_mobile, _leftCol),
+            wide: minWidthMaxWidth(_mobile, _wide),
+        },
+    },
+    mobileMedium: {
+        and: {
+            mobileLandscape: minWidthMaxWidth(_mobileMedium, _mobileLandscape),
+            phablet: minWidthMaxWidth(_mobileMedium, _phablet),
+            tablet: minWidthMaxWidth(_mobileMedium, _tablet),
+            desktop: minWidthMaxWidth(_mobileMedium, _desktop),
+            leftCol: minWidthMaxWidth(_mobileMedium, _leftCol),
+            wide: minWidthMaxWidth(_mobileMedium, _wide),
+        },
+    },
+    mobileLandscape: {
+        and: {
+            phablet: minWidthMaxWidth(_mobileLandscape, _phablet),
+            tablet: minWidthMaxWidth(_mobileLandscape, _tablet),
+            desktop: minWidthMaxWidth(_mobileLandscape, _desktop),
+            leftCol: minWidthMaxWidth(_mobileLandscape, _leftCol),
+            wide: minWidthMaxWidth(_mobileLandscape, _wide),
+        },
+    },
+    phablet: {
+        and: {
+            tablet: minWidthMaxWidth(_phablet, _tablet),
+            desktop: minWidthMaxWidth(_phablet, _desktop),
+            leftCol: minWidthMaxWidth(_phablet, _leftCol),
+            wide: minWidthMaxWidth(_phablet, _wide),
+        },
+    },
+    tablet: {
+        and: {
+            desktop: minWidthMaxWidth(_tablet, _desktop),
+            leftCol: minWidthMaxWidth(_tablet, _leftCol),
+            wide: minWidthMaxWidth(_tablet, _wide),
+        },
+    },
+    desktop: {
+        and: {
+            leftCol: minWidthMaxWidth(_desktop, _leftCol),
+            wide: minWidthMaxWidth(_desktop, _wide),
+        },
+    },
+    leftCol: {
+        and: { wide: minWidthMaxWidth(_leftCol, _wide) },
+    },
+};


### PR DESCRIPTION
cahnges the breakpoint exports from functions that take a string to finite objects, so that flow will complain if you try to use an invalid breakpoint

## before
`from('tablet')`
`until('mobileLandscape')`
`between('mobileLandscape', 'tablet')`

## now
`from.tablet` (or just `tablet`)
`until.mobileLandscape`
`between.mobileLandscape.and.tablet`

has handy side affect of providing us with autocomplete if you have it:
![image](https://user-images.githubusercontent.com/867233/36030212-3173bd9e-0d9e-11e8-9dbc-7875862cf483.png)
