### PR TITLE
Use dynamic import

### DIFF
--- a/__config__/webpack/webpack.config.dev.js
+++ b/__config__/webpack/webpack.config.dev.js
@@ -55,7 +55,7 @@ module.exports = {
                     const data = require(`../../.data/${pageType}`);
 
                     try {
-                        res.send(page(data));
+                        res.send(await page(data));
                     } catch (e) {
                         log(e);
                     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
         "react-dom": "^16.2.0",
         "react-emotion": "^9.0.2",
         "react-hot-loader": "^4.0.0-rc.0",
-        "require-dir": "^1.0.0",
         "reset-css": "^2.2.1"
     },
     "devDependencies": {

--- a/src/server.js
+++ b/src/server.js
@@ -2,17 +2,14 @@
 
 import { renderToString } from 'react-dom/server';
 import { extractCritical } from 'emotion-server';
-import requireDir from 'require-dir';
 import { ThemeProvider } from 'emotion-theming';
 import guTheme from 'styles/guTheme';
 
 import doc from 'lib/__html';
 
-const pages = requireDir('./pages');
-
-export default (state: { page: string }): string => {
-    const Page = pages[state.page].default;
-
+export default async (state: { page: string }): string => {
+    const pageModule = await import(`./pages/${state.page}`);
+    const Page = pageModule.default;
     const { html, ids: cssIDs, css } = extractCritical(
         renderToString(
             <ThemeProvider theme={guTheme}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4815,10 +4815,6 @@ require-coercible-to-string-x@^1.0.0:
     require-object-coercible-x "^1.4.1"
     to-string-x "^1.4.2"
 
-require-dir@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/require-dir/-/require-dir-1.0.0.tgz#c2639de72960ea1ee280279f2da35e03c6536b2d"
-
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"


### PR DESCRIPTION
## What does this change?

Use dynamic import instead of `require-dir`

## Why?

Prepares the ground for a production server
