### PR TITLE
Rename prop from "state" to "data"

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -8,16 +8,16 @@ import { hydrate as hydrateCSS } from 'emotion';
 // eslint-disable-next-line camelcase,no-undef
 __webpack_public_path__ = '/assets/javascript/';
 
-const { state, cssIDs } = window.gu.app;
+const { data, cssIDs } = window.gu.app;
 
 if (module.hot) {
     module.hot.accept();
 }
 
 // create code split points for all ../pages
-import(/* webpackChunkName: "[request]" */ `./pages/${state.page}`).then(
+import(/* webpackChunkName: "[request]" */ `./pages/${data.page}`).then(
     ({ default: Page }) => {
         hydrateCSS(cssIDs);
-        hydrateDOM(<Page state={state} />, document.getElementById('app'));
+        hydrateDOM(<Page data={data} />, document.getElementById('app'));
     },
 );

--- a/src/components/Header/Nav/index.js
+++ b/src/components/Header/Nav/index.js
@@ -30,7 +30,7 @@ const Nav = styled('nav')(
 );
 Nav.displayName = 'Nav';
 
-export default ({ state: { header } }) => (
+export default ({ data: { header } }) => (
     <Nav>
         <Logo href="/" />
         <Links links={header.links} />

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -15,8 +15,8 @@ const Header = styled('header')({
 });
 Header.displayName = 'Header';
 
-export default ({ state }) => (
+export default ({ data }) => (
     <Header>
-        <Nav state={state} />
+        <Nav data={data} />
     </Header>
 );

--- a/src/lib/__html.js
+++ b/src/lib/__html.js
@@ -9,14 +9,14 @@ export default ({
     cssIDs = '',
     html = '',
     jsApp = '/assets/javascript/app.browser.js',
-    state = {},
+    data = {},
     jsNonBlocking = '',
 }: {
     title?: string,
     css: string,
     html: string,
     jsApp?: string,
-    state?: {},
+    data?: {},
     jsNonBlocking?: string,
 }) => `
     <!doctype html>
@@ -31,7 +31,7 @@ export default ({
             <script>
             window.gu = {
                 app: {
-                    state: ${JSON.stringify(state)},
+                    app: ${JSON.stringify(data)},
                     cssIDs: ${JSON.stringify(cssIDs)},
                 }
             };

--- a/src/lib/__html.js
+++ b/src/lib/__html.js
@@ -31,7 +31,7 @@ export default ({
             <script>
             window.gu = {
                 app: {
-                    app: ${JSON.stringify(data)},
+                    data: ${JSON.stringify(data)},
                     cssIDs: ${JSON.stringify(cssIDs)},
                 }
             };

--- a/src/pages/Article.immersive.js
+++ b/src/pages/Article.immersive.js
@@ -2,4 +2,4 @@
 
 import Header from 'components/Header';
 
-export default ({ state }) => <Header state={state} />;
+export default ({ data }) => <Header data={data} />;

--- a/src/pages/Article.js
+++ b/src/pages/Article.js
@@ -2,6 +2,6 @@
 
 import Header from 'components/Header';
 
-const Article = ({ state }) => <Header state={state} />;
+const Article = ({ data }) => <Header data={data} />;
 
 export default Article;

--- a/src/server.js
+++ b/src/server.js
@@ -7,14 +7,14 @@ import { extractCritical } from 'emotion-server';
 
 import doc from 'lib/__html';
 
-const fetchPage = async (state: { page: string }): string => {
-    const pageModule = await import(`./pages/${state.page}`);
+const fetchPage = async (data: { page: string }): string => {
+    const pageModule = await import(`./pages/${data.page}`);
     const Page = pageModule.default;
     const { html, ids: cssIDs, css } = extractCritical(
-        renderToString(<Page state={state} />),
+        renderToString(<Page data={data} />),
     );
 
-    return doc({ html, state, css, cssIDs });
+    return doc({ html, data, css, cssIDs });
 };
 
 export default () => async (req, res) => {


### PR DESCRIPTION
Renames the `prop` "state" to "data" for clarity purposes.

Our `props` should be used for passing data from parent to child components, and should be  immutable whilst our `state` should be mutable and is used for interactivity to trigger re-renders.