### PR TITLE
Pull live data in

### DIFF
--- a/.data/article.immersive.js
+++ b/.data/article.immersive.js
@@ -1,4 +1,0 @@
-// @flow
-const common = require('./common');
-
-module.exports = { ...common, page: 'Article.immersive' };

--- a/.data/article.js
+++ b/.data/article.js
@@ -1,4 +1,0 @@
-// @flow
-const common = require('./common');
-
-module.exports = { ...common, page: 'Article' };

--- a/__data__/article.immersive.js
+++ b/__data__/article.immersive.js
@@ -1,0 +1,3 @@
+// @flow
+
+module.exports = { page: 'Article.immersive' };

--- a/__data__/article.js
+++ b/__data__/article.js
@@ -1,0 +1,3 @@
+// @flow
+
+module.exports = { page: 'Article' };

--- a/__data__/index.js
+++ b/__data__/index.js
@@ -1,5 +1,6 @@
 // @flow
-module.exports.header = {
+/* eslint-disable global-require,import/no-dynamic-require */
+const header = {
     links: [
         {
             text: 'Subscribe',
@@ -41,4 +42,17 @@ module.exports.header = {
             pillar: 'lifestyle',
         },
     ],
+};
+
+module.exports = page => {
+    let pageConfig = { page };
+    try {
+        pageConfig = require(`./${page}`);
+    } catch (e) {
+        // nothing
+    }
+    return {
+        header,
+        ...pageConfig,
+    };
 };

--- a/__tools__/dev-server.js
+++ b/__tools__/dev-server.js
@@ -55,7 +55,7 @@ app.get('/', (req, res) => {
 });
 
 app.get(
-    '/pages/*',
+    '/pages/:page',
     webpackHotServerMiddleware(compiler, {
         chunkName: 'app',
     }),

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "emotion": "^9.0.2",
         "emotion-server": "^9.0.2",
         "emotion-theming": "^9.0.0",
+        "node-fetch": "^2.1.1",
         "prop-types": "^15.6.0",
         "react": "^16.2.0",
         "react-dom": "^16.2.0",

--- a/src/pages/Article.js
+++ b/src/pages/Article.js
@@ -2,6 +2,11 @@
 
 import Header from 'components/Header';
 
-const Article = ({ data }) => <Header data={data} />;
+const Article = ({ data }) => (
+    <>
+        <Header data={data} />
+        <h1>{data.config.page.headline}</h1>
+    </>
+);
 
 export default Article;

--- a/src/server.js
+++ b/src/server.js
@@ -25,8 +25,8 @@ export default () => async (req, res) => {
     const data = fakeState(req.params.page);
 
     const { html: ignoreMe, ...config } = await fetch(
-        `https://www.theguardian.com/${req.query.url ||
-            'world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance'}.json`,
+        `${req.query.url ||
+            'https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance'}.json`,
     ).then(article => article.json());
 
     try {

--- a/src/server.js
+++ b/src/server.js
@@ -4,8 +4,11 @@
 import { log } from 'util';
 import { renderToString } from 'react-dom/server';
 import { extractCritical } from 'emotion-server';
+import fetch from 'node-fetch';
 
 import doc from 'lib/__html';
+
+import fakeState from '../__data__';
 
 const fetchPage = async (data: { page: string }): string => {
     const pageModule = await import(`./pages/${data.page}`);
@@ -18,11 +21,15 @@ const fetchPage = async (data: { page: string }): string => {
 };
 
 export default () => async (req, res) => {
-    const pageType = req.params[0].split('/pages/')[0];
-    const data = require(`../.data/${pageType}`);
+    // just while we're not getting a state from play
+    const data = fakeState(req.params.page);
+
+    const { html: ignoreMe, ...config } = await fetch(
+        'https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance.json',
+    ).then(article => article.json());
 
     try {
-        const html = await fetchPage(data);
+        const html = await fetchPage({ ...data, ...config });
         res.status(200).send(html);
     } catch (e) {
         log(e);

--- a/src/server.js
+++ b/src/server.js
@@ -25,7 +25,8 @@ export default () => async (req, res) => {
     const data = fakeState(req.params.page);
 
     const { html: ignoreMe, ...config } = await fetch(
-        'https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance.json',
+        `https://www.theguardian.com/${req.query.url ||
+            'world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance'}.json`,
     ).then(article => article.json());
 
     try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3976,6 +3976,10 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+node-fetch@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.1.tgz#369ca70b82f50c86496104a6c776d274f4e4a2d4"
+
 node-forge@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.1.tgz#9da611ea08982f4b94206b3beb4cc9665f20c300"


### PR DESCRIPTION
## What does this change?
pulls live data in from production stories in dev
- defaults to `https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance.json`
- add `url=https://www.theguardian.com/x` query param to see another article
## Why?
start to use real data