### PR TITLE
react ♻️ preact

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -52,16 +52,7 @@ const appServerConfig = {
 };
 
 const appBrowserConfig = {
-    plugins: [
-        '@babel/plugin-syntax-dynamic-import',
-        [
-            '@babel/plugin-transform-runtime',
-            {
-                polyfill: false,
-            },
-        ],
-        ...universalPlugins,
-    ],
+    plugins: ['@babel/plugin-syntax-dynamic-import', ...universalPlugins],
     presets: [
         [
             '@babel/preset-env',

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -4,7 +4,6 @@ const universalPlugins = [
     'babel-plugin-preval',
     ['@babel/plugin-proposal-object-rest-spread', { useBuiltIns: true }],
     '@babel/plugin-proposal-class-properties',
-    'babel-plugin-react-require',
     'babel-plugin-inline-react-svg',
     [
         'babel-plugin-module-resolver',
@@ -14,7 +13,10 @@ const universalPlugins = [
     ],
 ];
 
-const universalPresets = ['@babel/preset-flow', '@babel/preset-react'];
+const universalPresets = [
+    '@babel/preset-flow',
+    ['@babel/preset-react', { pragma: 'h' }],
+];
 
 const defaultConfig = {
     plugins: ['babel-plugin-dynamic-import-node', ...universalPlugins],

--- a/__config__/webpack/webpack.config.js
+++ b/__config__/webpack/webpack.config.js
@@ -20,6 +20,10 @@ const config = platform => ({
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
         }),
+        new webpack.ProvidePlugin({
+            h: ['preact', 'h'],
+            styled: ['preact-emotion', 'default'],
+        }),
     ],
     stats: 'errors-only',
     module: {
@@ -33,6 +37,12 @@ const config = platform => ({
                 },
             },
         ],
+    },
+    resolve: {
+        alias: {
+            // for libs that expect React
+            react: 'preact',
+        },
     },
 });
 

--- a/__config__/webpack/webpack.config.js
+++ b/__config__/webpack/webpack.config.js
@@ -9,7 +9,12 @@ const dist = path.resolve(__dirname, '../../dist');
 
 const config = platform => ({
     name: platform,
-    entry: { app: `./src/${platform}.js` },
+    entry: {
+        app: [
+            'preact-emotion', // force preact-emotion into the vendor chunk
+            `./src/${platform}.js`,
+        ],
+    },
     output: {
         path: dist,
         filename: `[name].${platform}.js`,

--- a/__config__/webpack/webpack.config.js
+++ b/__config__/webpack/webpack.config.js
@@ -27,7 +27,6 @@ const config = platform => ({
         }),
         new webpack.ProvidePlugin({
             h: ['preact', 'h'],
-            styled: ['preact-emotion', 'default'],
         }),
     ],
     stats: 'errors-only',

--- a/flow-typed/global.js
+++ b/flow-typed/global.js
@@ -1,5 +1,3 @@
-declare var React: $Exports<'react'>;
-declare var styled: $Exports<'preact-emotion'>;
 declare var __webpack_public_path__: string;
 declare var module: {
     hot: {

--- a/flow-typed/global.js
+++ b/flow-typed/global.js
@@ -1,4 +1,5 @@
 declare var React: $Exports<'react'>;
+declare var styled: $Exports<'preact-emotion'>;
 declare var __webpack_public_path__: string;
 declare var module: {
     hot: {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
         "emotion": "^9.0.2",
         "emotion-server": "^9.0.2",
         "node-fetch": "^2.1.1",
+        "preact": "^8.2.7",
+        "preact-emotion": "^9.0.2",
+        "preact-render-to-string": "^3.7.0",
         "prop-types": "^15.6.0",
-        "react": "^16.2.0",
-        "react-dom": "^16.2.0",
-        "react-emotion": "^9.0.2",
         "reset-css": "^2.2.1",
         "unistore": "^3.0.4"
     },
@@ -39,7 +39,6 @@
         "babel-plugin-inline-react-svg": "^0.5.2",
         "babel-plugin-module-resolver": "^3.1.0",
         "babel-plugin-preval": "^1.6.3",
-        "babel-plugin-react-require": "^3.0.0",
         "chalk": "^2.3.0",
         "decamelize": "^2.0.0",
         "eslint": "^4.18.0",
@@ -78,7 +77,7 @@
     "eslintConfig": {
         "parser": "babel-eslint",
         "globals": {
-            "React": false
+            "styled": false
         },
         "parserOptions": {
             "ecmaVersion": "2017",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslintConfig": {
         "parser": "babel-eslint",
         "globals": {
-            "styled": false
+
         },
         "parserOptions": {
             "ecmaVersion": "2017",

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,10 +1,10 @@
 // @flow
 
 // $FlowFixMe https://github.com/facebook/flow/issues/5035
-import { hydrate as hydrateDOM } from 'react-dom';
+import { render } from 'preact';
 import { hydrate as hydrateCSS } from 'emotion';
 import createStore from 'unistore';
-import { Provider } from 'unistore/react';
+import { Provider } from 'unistore/preact';
 
 // webpack-specific
 // eslint-disable-next-line camelcase,no-undef
@@ -14,17 +14,19 @@ const { data, cssIDs } = window.gu.app;
 
 if (module.hot) {
     module.hot.accept();
+    require('preact/debug'); // eslint-disable-line global-require
 }
 
+const init = ({ default: Page }) => {
+    hydrateCSS(cssIDs);
+    render(
+        <Provider store={createStore(data)}>
+            <Page />
+        </Provider>,
+        document.getElementById('app'),
+        document.getElementById('app').lastElementChild,
+    );
+};
+
 // create code split points for all ../pages
-import(/* webpackChunkName: "[request]" */ `./pages/${data.page}`).then(
-    ({ default: Page }) => {
-        hydrateCSS(cssIDs);
-        hydrateDOM(
-            <Provider store={createStore(data)}>
-                <Page />
-            </Provider>,
-            document.getElementById('app'),
-        );
-    },
-);
+import(/* webpackChunkName: "[request]" */ `./pages/${data.page}`).then(init);

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,7 +1,5 @@
 // @flow
 
-import styled from 'react-emotion';
-
 const pillarColours = {
     news: 'pink',
     alex: 'hotpink',

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,4 +1,5 @@
 // @flow
+import styled from 'preact-emotion';
 
 const pillarColours = {
     news: 'pink',

--- a/src/components/Header/Nav/Links/Link.js
+++ b/src/components/Header/Nav/Links/Link.js
@@ -1,4 +1,5 @@
 // @flow
+import styled from 'preact-emotion';
 
 import palette from 'pasteup/palette';
 import { textSans } from 'pasteup/fonts';

--- a/src/components/Header/Nav/Links/Link.js
+++ b/src/components/Header/Nav/Links/Link.js
@@ -1,5 +1,4 @@
 // @flow
-import styled from 'react-emotion';
 
 import palette from 'pasteup/palette';
 import { textSans } from 'pasteup/fonts';

--- a/src/components/Header/Nav/Links/Search.js
+++ b/src/components/Header/Nav/Links/Search.js
@@ -1,4 +1,5 @@
 // @flow
+import styled from 'preact-emotion';
 
 import Link from './Link';
 

--- a/src/components/Header/Nav/Links/Search.js
+++ b/src/components/Header/Nav/Links/Search.js
@@ -1,5 +1,4 @@
 // @flow
-import styled from 'react-emotion';
 
 import Link from './Link';
 

--- a/src/components/Header/Nav/Links/SupportTheGuardian.js
+++ b/src/components/Header/Nav/Links/SupportTheGuardian.js
@@ -1,7 +1,5 @@
 // @flow
 
-import styled from 'react-emotion';
-
 import palette, { pillars } from 'pasteup/palette';
 import { headline } from 'pasteup/fonts';
 

--- a/src/components/Header/Nav/Links/SupportTheGuardian.js
+++ b/src/components/Header/Nav/Links/SupportTheGuardian.js
@@ -1,4 +1,5 @@
 // @flow
+import styled from 'preact-emotion';
 
 import palette, { pillars } from 'pasteup/palette';
 import { headline } from 'pasteup/fonts';

--- a/src/components/Header/Nav/Links/index.js
+++ b/src/components/Header/Nav/Links/index.js
@@ -1,6 +1,5 @@
 // @flow
-import styled from 'react-emotion';
-import { connect } from 'unistore/react';
+import { connect } from 'unistore/preact';
 
 import SupportTheGuardian from './SupportTheGuardian';
 import Link from './Link';

--- a/src/components/Header/Nav/Links/index.js
+++ b/src/components/Header/Nav/Links/index.js
@@ -1,4 +1,5 @@
 // @flow
+import styled from 'preact-emotion';
 import { connect } from 'unistore/preact';
 
 import SupportTheGuardian from './SupportTheGuardian';

--- a/src/components/Header/Nav/Logo.js
+++ b/src/components/Header/Nav/Logo.js
@@ -1,4 +1,5 @@
 // @flow
+import styled from 'preact-emotion';
 
 import {
     mobileMedium,

--- a/src/components/Header/Nav/Logo.js
+++ b/src/components/Header/Nav/Logo.js
@@ -1,5 +1,4 @@
 // @flow
-import styled from 'react-emotion';
 
 import {
     mobileMedium,

--- a/src/components/Header/Nav/Pillars/Pillar.js
+++ b/src/components/Header/Nav/Pillars/Pillar.js
@@ -1,5 +1,4 @@
 // @flow
-import styled from 'react-emotion';
 
 import { tablet, desktop } from 'pasteup/breakpoints';
 import { pillars } from 'pasteup/palette';

--- a/src/components/Header/Nav/Pillars/Pillar.js
+++ b/src/components/Header/Nav/Pillars/Pillar.js
@@ -1,4 +1,5 @@
 // @flow
+import styled from 'preact-emotion';
 
 import { tablet, desktop } from 'pasteup/breakpoints';
 import { pillars } from 'pasteup/palette';

--- a/src/components/Header/Nav/Pillars/index.js
+++ b/src/components/Header/Nav/Pillars/index.js
@@ -1,7 +1,5 @@
 // @flow
-// .pillars
-import styled from 'react-emotion';
-import { connect } from 'unistore/react';
+import { connect } from 'unistore/preact';
 
 import { mobileLandscape } from 'pasteup/breakpoints';
 

--- a/src/components/Header/Nav/Pillars/index.js
+++ b/src/components/Header/Nav/Pillars/index.js
@@ -1,4 +1,5 @@
 // @flow
+import styled from 'preact-emotion';
 import { connect } from 'unistore/preact';
 
 import { mobileLandscape } from 'pasteup/breakpoints';

--- a/src/components/Header/Nav/index.js
+++ b/src/components/Header/Nav/index.js
@@ -1,4 +1,5 @@
 // @flow
+import styled from 'preact-emotion';
 
 import { clearFix } from 'pasteup/mixins';
 import { tablet, desktop, leftCol, wide } from 'pasteup/breakpoints';

--- a/src/components/Header/Nav/index.js
+++ b/src/components/Header/Nav/index.js
@@ -1,7 +1,5 @@
 // @flow
 
-import styled from 'react-emotion';
-
 import { clearFix } from 'pasteup/mixins';
 import { tablet, desktop, leftCol, wide } from 'pasteup/breakpoints';
 

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,4 +1,5 @@
 // @flow
+import styled from 'preact-emotion';
 
 import { tablet } from 'pasteup/breakpoints';
 

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,5 +1,4 @@
 // @flow
-import styled from 'react-emotion';
 
 import { tablet } from 'pasteup/breakpoints';
 

--- a/src/pages/Article.js
+++ b/src/pages/Article.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { connect } from 'unistore/react';
+import { connect } from 'unistore/preact';
 
 import Header from 'components/Header';
 

--- a/src/server.js
+++ b/src/server.js
@@ -2,10 +2,10 @@
 /* eslint-disable global-require,import/no-dynamic-require */
 
 import { log } from 'util';
-import { renderToString } from 'react-dom/server';
+import renderToString from 'preact-render-to-string';
 import { extractCritical } from 'emotion-server';
 import createStore from 'unistore';
-import { Provider } from 'unistore/react';
+import { Provider } from 'unistore/preact';
 
 import doc from 'lib/__html';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,10 +1012,6 @@ babel-plugin-preval@^1.6.3:
     babylon "^6.18.0"
     require-from-string "^2.0.1"
 
-babel-plugin-react-require@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz#2e4e7b4496b93a654a1c80042276de4e4eeb20e3"
-
 babel-plugin-syntax-dynamic-import@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
@@ -3668,7 +3664,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -4399,6 +4395,23 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
+preact-emotion@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/preact-emotion/-/preact-emotion-9.0.2.tgz#927ad240464a4d9101d3721dcc0f62a3ced4521e"
+  dependencies:
+    babel-plugin-emotion "^9.0.1"
+    create-emotion-styled "^9.0.1"
+
+preact-render-to-string@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-3.7.0.tgz#7db4177454bc01395e0d01d6ac07bc5e838e31ee"
+  dependencies:
+    pretty-format "^3.5.1"
+
+preact@^8.2.7:
+  version "8.2.7"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.7.tgz#316249fb678cd5e93e7cee63cea7bfb62dbd6814"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -4417,6 +4430,10 @@ pretty-bytes@^1.0.0:
   dependencies:
     get-stdin "^4.0.1"
     meow "^3.1.0"
+
+pretty-format@^3.5.1:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
 
 printable-characters@^1.0.37:
   version "1.0.38"
@@ -4561,31 +4578,6 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-dom@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
-react-emotion@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/react-emotion/-/react-emotion-9.0.2.tgz#99ec26cb9ad671fff393338354543ff7c2540ae1"
-  dependencies:
-    babel-plugin-emotion "^9.0.1"
-    create-emotion-styled "^9.0.1"
-
-react@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## What does this change?
- swaps react for preact
- ~~makes `styled` available in module scope (should it?)~~ one for another time
## Why?
bundle size. if preact becomes too tricky we'll swap back. 

### before (including #47)
```
Article-immersive.browser.js  15.93 kB → 6.71 kB (gzip)
Article.browser.js            16.09 kB → 6.76 kB (gzip)
app.browser.js                1.09 kB → 622 B (gzip)
vendor.browser.js             140.44 kB → 46.19 kB (gzip)
```
### after
```
Article-immersive.browser.js  11.77 kB → 4.17 kB (gzip)
Article.browser.js            11.88 kB → 4.22 kB (gzip)
app.browser.js                872 B → 528 B (gzip)
vendor.browser.js             37.6 kB → 14.56 kB (gzip)
```