### PR TITLE
Riffraff assets fix

### DIFF
--- a/__tasks__/build-riffraff-artifact.sh
+++ b/__tasks__/build-riffraff-artifact.sh
@@ -16,7 +16,7 @@ if [[ -z $BRANCH_NAME ]]; then
   BRANCH_NAME=unknown
 fi
 
-$TARGET_ROOT=target/guui
+TARGET_ROOT=target/guui
 
 zip -r guui.zip * -x node_modules/**\*
 [ -d target ] && rm -rf target

--- a/__tasks__/build-riffraff-artifact.sh
+++ b/__tasks__/build-riffraff-artifact.sh
@@ -16,12 +16,14 @@ if [[ -z $BRANCH_NAME ]]; then
   BRANCH_NAME=unknown
 fi
 
+$TARGET_ROOT=target/guui
+
 zip -r guui.zip * -x node_modules/**\*
 [ -d target ] && rm -rf target
-mkdir -p target/dist
-mkdir -p target/cfn
-mv guui.zip ./target/dist/guui.zip
-cp __config__/cfn/cloudformation.yml ./target/cfn
+mkdir -p $TARGET_ROOT/dist
+mkdir -p $TARGET_ROOT/cfn
+mv guui.zip ./$TARGET_ROOT/dist/guui.zip
+cp __config__/cfn/cloudformation.yml ./$TARGET_ROOT/cfn
 
 cp riff-raff.yaml target
 


### PR DESCRIPTION
## What does this change?

RiffRaff is having trouble seeing the assets we're sending it. After combing the docs I found (with some difficulty) that it might expect them to be underneath a guui directory so I'm making target/guui the top level instead of just target in the bundle we send to upload to the riffraff artifacts bucket

I can test by asking riffraff to deploy the build on this branch, will report back if it works!

## Why?

Guui is still cloning down the repo from github, we need to get artifacts pushed through properly.