### PR TITLE
Asset hashing

### DIFF
--- a/__config__/webpack/helpers.js
+++ b/__config__/webpack/helpers.js
@@ -2,10 +2,8 @@
 const path = require('path');
 const fs = require('fs');
 
-module.exports.dist = path.resolve(__dirname, '../../dist');
-
 module.exports.pages = fs
-    .readdirSync(path.resolve(__dirname, '../../src/pages'))
+    .readdirSync(path.resolve(__dirname, '..', '..', 'src', 'pages'))
     .map(filename => filename.split('.js')[0]);
 
 module.exports.injectPage = page =>

--- a/__config__/webpack/paths.js
+++ b/__config__/webpack/paths.js
@@ -1,0 +1,4 @@
+// @flow
+const path = require('path');
+
+module.exports.dist = path.resolve(__dirname, '..', '..', 'dist');

--- a/__config__/webpack/webpack.config.development.js
+++ b/__config__/webpack/webpack.config.development.js
@@ -24,6 +24,9 @@ module.exports = {
             }),
             {},
         ),
+        output: {
+            pathinfo: true,
+        },
         plugins: [
             new webpack.HotModuleReplacementPlugin(),
             new webpack.NamedModulesPlugin(),

--- a/__config__/webpack/webpack.config.js
+++ b/__config__/webpack/webpack.config.js
@@ -12,8 +12,8 @@ const config = ({ platform }) => ({
     name: platform,
     output: {
         path: dist,
-        filename: `[name].${platform}.js`,
-        chunkFilename: `[name].${platform}.js`,
+        filename: `[name].js`,
+        chunkFilename: `[name].js`,
         publicPath: '/assets/javascript/',
     },
     plugins: [
@@ -52,7 +52,7 @@ module.exports = [
         config({ platform: 'server' }),
         {
             entry: {
-                app: ['./src/server.js'],
+                server: ['./src/server.js'],
             },
             target: 'node',
             externals: [require('webpack-node-externals')()],

--- a/__config__/webpack/webpack.config.js
+++ b/__config__/webpack/webpack.config.js
@@ -78,7 +78,7 @@ module.exports = [
         {
             entry: pages.reduce(
                 (entries, page) => ({
-                    [page]: injectPage(page),
+                    [page.toLowerCase()]: injectPage(page),
                     ...entries,
                 }),
                 {},

--- a/__config__/webpack/webpack.config.js
+++ b/__config__/webpack/webpack.config.js
@@ -75,6 +75,15 @@ module.exports = [
                 }),
                 {},
             ),
+            plugins: [
+                new webpack.optimize.CommonsChunkPlugin({
+                    name: 'vendor',
+                    minChunks: ({ context }) =>
+                        context &&
+                        (context.includes('node_modules') ||
+                            context.includes('pasteup')),
+                }),
+            ],
         },
         envConfig.browser,
     ),

--- a/__config__/webpack/webpack.config.js
+++ b/__config__/webpack/webpack.config.js
@@ -5,7 +5,8 @@ const webpack = require('webpack');
 // https://github.com/survivejs/webpack-merge#smart-merging
 const { smart: merge } = require('webpack-merge');
 
-const { pages, injectPage, dist } = require('./helpers');
+const { pages, injectPage } = require('./helpers');
+const { dist } = require('./paths');
 
 const config = ({ platform }) => ({
     name: platform,

--- a/__config__/webpack/webpack.config.js
+++ b/__config__/webpack/webpack.config.js
@@ -55,7 +55,15 @@ module.exports = [
                 server: ['./src/server.js'],
             },
             target: 'node',
-            externals: [require('webpack-node-externals')()],
+            externals: [
+                require('webpack-node-externals')(),
+                (context, request, callback) => {
+                    if (/manifest\.json$/.test(request)) {
+                        return callback(null, `commonjs ${request}`);
+                    }
+                    callback();
+                },
+            ],
             output: {
                 libraryTarget: 'commonjs2',
                 pathinfo: true,

--- a/__config__/webpack/webpack.config.js
+++ b/__config__/webpack/webpack.config.js
@@ -58,6 +58,7 @@ module.exports = [
             externals: [require('webpack-node-externals')()],
             output: {
                 libraryTarget: 'commonjs2',
+                pathinfo: true,
             },
         },
         envConfig.server,

--- a/__config__/webpack/webpack.config.production.js
+++ b/__config__/webpack/webpack.config.production.js
@@ -17,12 +17,6 @@ module.exports = {
         plugins: [
             new webpack.optimize.ModuleConcatenationPlugin(),
             new webpack.optimize.OccurrenceOrderPlugin(),
-            new webpack.optimize.CommonsChunkPlugin({
-                name: 'vendor',
-                minChunks: ({ context = '' }) =>
-                    context.includes('node_modules') ||
-                    context.includes('pasteup'),
-            }),
             new webpack.optimize.UglifyJsPlugin({
                 sourceMap: true,
                 parallel: true,

--- a/__config__/webpack/webpack.config.production.js
+++ b/__config__/webpack/webpack.config.production.js
@@ -7,7 +7,7 @@ const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const ReportBundleSize = require('../../__tools__/report-bundle-size');
 const Progress = require('simple-progress-webpack-plugin');
 
-const { dist } = require('./helpers');
+const { dist } = require('./paths');
 
 const reportBundleSize = new ReportBundleSize({ configCount: 2 });
 

--- a/__config__/webpack/webpack.config.production.js
+++ b/__config__/webpack/webpack.config.production.js
@@ -22,6 +22,7 @@ module.exports = {
         plugins: [
             new webpack.optimize.ModuleConcatenationPlugin(),
             new webpack.optimize.OccurrenceOrderPlugin(),
+            new webpack.HashedModuleIdsPlugin(),
             new webpack.optimize.UglifyJsPlugin({
                 sourceMap: true,
                 parallel: true,

--- a/__config__/webpack/webpack.config.production.js
+++ b/__config__/webpack/webpack.config.production.js
@@ -22,7 +22,7 @@ module.exports = {
                 parallel: true,
             }),
             new BundleAnalyzerPlugin({
-                reportFilename: path.join(dist, `app.browser.stats.html`),
+                reportFilename: path.join(dist, 'browser-stats.html'),
                 analyzerMode: 'static',
                 openAnalyzer: false,
                 logLevel: 'warn',
@@ -36,6 +36,14 @@ module.exports = {
     },
     server: {
         devtool: 'source-map',
-        plugins: [reportBundleSize],
+        plugins: [
+            reportBundleSize,
+            new BundleAnalyzerPlugin({
+                reportFilename: path.join(dist, 'server-stats.html'),
+                analyzerMode: 'static',
+                openAnalyzer: false,
+                logLevel: 'warn',
+            }),
+        ],
     },
 };

--- a/__config__/webpack/webpack.config.production.js
+++ b/__config__/webpack/webpack.config.production.js
@@ -6,6 +6,7 @@ const webpack = require('webpack');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const ReportBundleSize = require('../../__tools__/report-bundle-size');
 const Progress = require('simple-progress-webpack-plugin');
+const AssetsManifest = require('webpack-assets-manifest');
 
 const { dist } = require('./paths');
 
@@ -13,6 +14,10 @@ const reportBundleSize = new ReportBundleSize({ configCount: 2 });
 
 module.exports = {
     browser: {
+        output: {
+            filename: `[name].[chunkhash].js`,
+            chunkFilename: `[name].[chunkhash].js`,
+        },
         devtool: 'source-map',
         plugins: [
             new webpack.optimize.ModuleConcatenationPlugin(),
@@ -27,6 +32,7 @@ module.exports = {
                 openAnalyzer: false,
                 logLevel: 'warn',
             }),
+            new AssetsManifest({ writeToDisk: true }),
             !process.env.CI &&
                 new Progress({
                     format: 'compact',

--- a/__server__/development.js
+++ b/__server__/development.js
@@ -46,7 +46,7 @@ app.use('/pages/:page', [
         next();
     },
     webpackHotServerMiddleware(compiler, {
-        chunkName: 'app',
+        chunkName: 'server',
     }),
 ]);
 

--- a/__server__/development.js
+++ b/__server__/development.js
@@ -22,6 +22,7 @@ app.use(
     webpackDevMiddleware(compiler, {
         serverSideRender: true,
         logLevel: 'silent',
+        publicPath: '/assets/javascript/',
     }),
 );
 

--- a/__server__/production.js
+++ b/__server__/production.js
@@ -5,7 +5,7 @@ const express = require('express');
 // eslint-disable-next-line import/no-unresolved
 const pagesMiddleware = require('../dist/app.server.js').default;
 const fetch = require('node-fetch');
-const { dist } = require('../__config__/webpack/helpers');
+const { dist } = require('../__config__/webpack/paths');
 
 const app = express();
 

--- a/__server__/production.js
+++ b/__server__/production.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const express = require('express');
 // eslint-disable-next-line import/no-unresolved
-const pagesMiddleware = require('../dist/app.server.js').default;
+const pagesMiddleware = require('../dist/server').default;
 const fetch = require('node-fetch');
 const { dist } = require('../__config__/webpack/paths');
 

--- a/__tools__/report-bundle-size.js
+++ b/__tools__/report-bundle-size.js
@@ -28,7 +28,7 @@ module.exports = class {
                 '';
 
             Object.entries(compilation.assets)
-                .filter(([key]) => !key.endsWith('map'))
+                .filter(([key]) => key.endsWith('js'))
                 .forEach(([file, value]) => {
                     this.messages[file] =
                         platform === 'server'

--- a/makefile
+++ b/makefile
@@ -27,7 +27,10 @@ start: stop
 	$(call log, "PROD server is running at http://localhost:9000")
 
 stop:
-	@./node_modules/.bin/pm2 kill
+	@env pm2 kill
+
+monitor:
+	@env pm2 monit
 
 deploy:
 	@env ./__tasks__/build-riffraff-artifact.sh

--- a/makefile
+++ b/makefile
@@ -8,13 +8,16 @@ endef
 
 # app #########################################
 
-build: clear install
+clean-dist:
+	$(call log, "deleting old artefacts")
+	@rm -rf dist
+
+build: clear install clean-dist
 	$(call log, "building production bundles")
 	@echo '' # just a spacer
-	@rm -rf dist
 	@NODE_ENV=production webpack --bail --color --config __config__/webpack/webpack.config.js
 
-dev: clear install
+dev: clear install clean-dist
 	$(call log, "starting DEV server...")
 	@NODE_ENV=development node __server__/development.js
 
@@ -58,11 +61,11 @@ install: check-env
 	$(call log, "refreshing dependencies")
 	@yarn >/dev/null
 
-clean:
+clean-modules:
 	$(call log, "trashing dependencies")
 	@rm -rf node_modules
 
-reinstall: clear clean install
+reinstall: clear clean-modules install
 	$(call log, "dependencies have been reinstalled ♻️")
 
 validate-build: # private
@@ -76,4 +79,4 @@ check-env: # private
 	@node __tasks__/check-yarn.js
 
 clear: # private
-	clear
+	@clear

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "simple-progress-webpack-plugin": "^1.1.0",
         "string-replace-loader": "^2.1.1",
         "webpack": "^3.11.0",
+        "webpack-assets-manifest": "1",
         "webpack-bundle-analyzer": "^2.10.0",
         "webpack-dev-middleware": "^2.0.6",
         "webpack-dev-server": "^2.11.1",

--- a/src/__lib__/asset-path.js
+++ b/src/__lib__/asset-path.js
@@ -1,0 +1,12 @@
+// @flow
+
+let assetHash = {};
+try {
+    // path is relative to the server bundle
+    // eslint-disable-next-line global-require,import/no-unresolved
+    assetHash = require('./manifest.json');
+} catch (e) {
+    // do nothing
+}
+
+export default name => `/assets/javascript/${assetHash[name] || name}`;

--- a/src/__lib__/html.js
+++ b/src/__lib__/html.js
@@ -1,6 +1,7 @@
 // @flow
 
 import resetCSS from './reset-css';
+import hashedAsset from './asset-path';
 
 export default ({
     title = 'The Guardian',
@@ -15,16 +16,18 @@ export default ({
     html: string,
     data?: {},
     jsNonBlocking?: string,
-}) => `
+}) => {
+    const bundle = hashedAsset(`${data.page}.js`);
+    const vendor = hashedAsset('vendor.js');
+
+    return `
     <!doctype html>
     <html>
         <head>
             <title>${title}</title>
             <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-            <link rel="preload" href="/static/css/fonts.css" as="style">
-            <link rel="preload" href="/assets/javascript/${
-                data.page
-            }.browser.js" as="script">
+            <link rel="preload" href="${vendor}" as="script">
+            <link rel="preload" href="${bundle}" as="script">
             <link rel="stylesheet" href="/static/css/fonts.css" media="nope!" onload="this.media='all'">
             <style>${resetCSS}${css}</style>
         </head>
@@ -38,8 +41,10 @@ export default ({
                 },
             })};
             </script>
-            <script src="/assets/javascript/${data.page}.browser.js"></script>
+            <script src="${vendor}"></script>
+            <script src="${bundle}"></script>
             <script>${jsNonBlocking}</script>
         </body>
     </html>
 `;
+};

--- a/src/__lib__/html.js
+++ b/src/__lib__/html.js
@@ -17,7 +17,7 @@ export default ({
     data?: {},
     jsNonBlocking?: string,
 }) => {
-    const bundle = hashedAsset(`${data.page}.js`);
+    const bundle = hashedAsset(`${data.page.toLowerCase()}.js`);
     const vendor = hashedAsset('vendor.js');
 
     return `

--- a/src/browser.js
+++ b/src/browser.js
@@ -10,10 +10,6 @@ import { Provider } from 'unistore/preact';
 // eslint-disable-next-line import/no-extraneous-dependencies,import/no-unresolved,import/extensions
 import Page from '__PAGE__ENTRY__POINT__';
 
-// webpack-specific
-// eslint-disable-next-line camelcase,no-undef
-__webpack_public_path__ = '/assets/javascript/';
-
 const { data, cssIDs } = window.gu.app;
 
 if (module.hot) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -715,6 +715,12 @@ ansi-styles@^3.2.0:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
+
 anymatch@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
@@ -1453,6 +1459,14 @@ chalk@^1.0.0, chalk@^1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^2.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -3947,6 +3961,14 @@ lodash.findindex@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.findindex/-/lodash.findindex-4.6.0.tgz#a3245dee61fb9b6e0624b535125624bb69c11106"
 
+lodash.get@^4.0:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
+lodash.has@^4.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
+
 lodash.isequal@^4.0.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -3959,9 +3981,17 @@ lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
 
-lodash.merge@^4.6.0:
+lodash.keys@^4.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
+
+lodash.merge@^4.0, lodash.merge@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
+
+lodash.pick@^4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -4215,7 +4245,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -5879,6 +5909,12 @@ supports-color@^5.1.0, supports-color@^5.2.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+  dependencies:
+    has-flag "^3.0.0"
+
 svgo@^0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"
@@ -6406,6 +6442,18 @@ wcwidth@^1.0.0:
 webidl-conversions@^4.0.1, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+
+webpack-assets-manifest@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/webpack-assets-manifest/-/webpack-assets-manifest-1.0.0.tgz#54a1bc4036e2eed2b3ce1fd6a7e31c09be99538a"
+  dependencies:
+    chalk "^2.0"
+    lodash.get "^4.0"
+    lodash.has "^4.0"
+    lodash.keys "^4.0"
+    lodash.merge "^4.0"
+    lodash.pick "^4.0"
+    mkdirp "^0.5"
 
 webpack-bundle-analyzer@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
## What does this change?

- hashes assets in prod
- writes a manifest that points entry names to their hashes versions for html template

some other bits fell out of it:
- bit more debug info in server bundle (and dev browser)
- uses commons chunk in dev, to align prod and dev better

## Why?

long term caching and makes sure we load the right bundles in prod
