### PR TITLE
emotion source maps

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -57,7 +57,7 @@ const appBrowserConfig = {
         [
             "emotion",
             {
-                "sourceMap": true,
+                "sourceMap": process.env.NODE_ENV !== 'production',
             }
         ],
         ...universalPlugins

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -57,7 +57,7 @@ const appBrowserConfig = {
         [
             'emotion',
             {
-                'sourceMap': process.env.NODE_ENV !== 'production',
+                sourceMap: process.env.NODE_ENV !== 'production',
             },
         ],
         ...universalPlugins,

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -55,12 +55,12 @@ const appBrowserConfig = {
     plugins: [
         '@babel/plugin-syntax-dynamic-import',
         [
-            "emotion",
+            'emotion',
             {
-                "sourceMap": process.env.NODE_ENV !== 'production',
-            }
+                'sourceMap': process.env.NODE_ENV !== 'production',
+            },
         ],
-        ...universalPlugins
+        ...universalPlugins,
     ],
     presets: [
         [

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -52,7 +52,16 @@ const appServerConfig = {
 };
 
 const appBrowserConfig = {
-    plugins: ['@babel/plugin-syntax-dynamic-import', ...universalPlugins],
+    plugins: [
+        '@babel/plugin-syntax-dynamic-import',
+        [
+            "emotion",
+            {
+                "sourceMap": true,
+            }
+        ],
+        ...universalPlugins
+    ],
     presets: [
         [
             '@babel/preset-env',

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "babel-eslint": "^8.2.1",
         "babel-loader": "^8.0.0-beta.0",
         "babel-plugin-dynamic-import-node": "^1.2.0",
+        "babel-plugin-emotion": "^9.0.1",
         "babel-plugin-inline-react-svg": "^0.5.2",
         "babel-plugin-module-resolver": "^3.1.0",
         "babel-plugin-preval": "^1.6.3",


### PR DESCRIPTION
## What does this change?

Enabling source maps during development allows developers to trace the source of styles applied in the JS via `emotion`.

## Why?

Better dev experience