### PR TITLE
Move header and epic to article

### DIFF
--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -1,7 +1,5 @@
 // @flow
 import styled from 'preact-emotion';
-import Header from 'components/Header';
-import Epic from 'components/Epic';
 
 import {
     mobileLandscape,
@@ -34,24 +32,5 @@ const PageWrapper = styled('div')({
 });
 
 export default function Page({ children }) {
-    return (
-        <PageWrapper>
-            <Header />
-            {children}
-            <Epic>
-                <strong>
-                    Unlike many news organisations, we haven’t put up a paywall
-                    – we want to keep our journalism as open as we can.
-                </strong>{' '}
-                The Guardian’s independent, investigative journalism takes a lot
-                of time, money and hard work to produce. But the revenue we get
-                from advertising is falling, so we increasingly need our readers
-                to fund us. If everyone who reads our reporting, who likes it,
-                helps fund it, our future would be much more secure.{' '}
-                <strong>
-                    Support The Guardian for just 17p a day or £5 a month.
-                </strong>
-            </Epic>
-        </PageWrapper>
-    );
+    return <PageWrapper>{children}</PageWrapper>;
 }

--- a/src/pages/Article.js
+++ b/src/pages/Article.js
@@ -9,6 +9,9 @@ import { textEgyptian, headline } from 'pasteup/fonts';
 import palette from 'pasteup/palette';
 import { clearFix } from 'pasteup/mixins';
 
+import Header from 'components/Header';
+import Epic from 'components/Epic';
+
 const Headline = styled('h1')({
     fontFamily: headline,
     fontSize: 34,
@@ -87,6 +90,7 @@ const SeriesLabel = styled(SectionLabel)({
 
 export default connect('content')(({ content }) => (
     <article>
+        <Header />
         <Labels>
             <SectionLabel>The NSA files</SectionLabel>
             <SeriesLabel>Glenn Greenwald on security and liberty</SeriesLabel>
@@ -108,5 +112,19 @@ export default connect('content')(({ content }) => (
                 __html: content.body,
             }}
         />
+        <Epic>
+            <strong>
+                Unlike many news organisations, we haven’t put up a paywall – we
+                want to keep our journalism as open as we can.
+            </strong>{' '}
+            The Guardian’s independent, investigative journalism takes a lot of
+            time, money and hard work to produce. But the revenue we get from
+            advertising is falling, so we increasingly need our readers to fund
+            us. If everyone who reads our reporting, who likes it, helps fund
+            it, our future would be much more secure.{' '}
+            <strong>
+                Support The Guardian for just 17p a day or £5 a month.
+            </strong>
+        </Epic>
     </article>
 ));


### PR DESCRIPTION
## What does this change?

The Header and Epic don't belong on every page. At the moment, they only belong on the Article.

Moving these components to the article ensure they don't appear on the NotFound page

## Why?

Because...

![picture 532](https://user-images.githubusercontent.com/5931528/38311334-d7f56d46-3816-11e8-85b6-4c8700dd81b4.png)
