### PR TITLE
Remove temporary production middleware

### DIFF
--- a/__server__/production.js
+++ b/__server__/production.js
@@ -4,26 +4,16 @@ const path = require('path');
 const express = require('express');
 // eslint-disable-next-line import/no-unresolved
 const pagesMiddleware = require('../dist/server').default;
-const fetch = require('node-fetch');
 const { dist } = require('../__config__/webpack/paths');
 
 const app = express();
 
+app.use(express.json({ limit: '50mb' }));
+
 app.use('/static', express.static(path.join(__dirname, '..', 'src', 'static')));
 app.use('/assets/javascript', express.static(dist));
 
-app.use('/pages/:page', [
-    async (req, res, next) => {
-        // TODO: get config from request
-        const { html, ...config } = await fetch(
-            `${req.query.url ||
-                'https://www.theguardian.com/world/2013/jun/09/edward-snowden-nsa-whistleblower-surveillance'}.json?guui`,
-        ).then(article => article.json());
-        req.body = config;
-        next();
-    },
-    pagesMiddleware(),
-]);
+app.use('/pages/:page', [pagesMiddleware()]);
 
 // eslint-disable-next-line no-unused-vars
 app.use((err, req, res, next) => {


### PR DESCRIPTION
## What does this change?

When guardian/frontend#19496 is merged, we'll be able to get the article data from the body of the request. We can therefore remove this middleware, and replace it with the express body parser.

## Why?

Integrates frontend with guui