### PR TITLE
Such grid

### DIFF
--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -1,33 +1,22 @@
 // @flow
 import styled from 'preact-emotion';
 
-import {
-    mobileLandscape,
-    tablet,
-    desktop,
-    leftCol,
-    wide,
-} from 'pasteup/breakpoints';
+import { tablet, desktop, leftCol, wide } from 'pasteup/breakpoints';
+import { calculateWidth } from 'pasteup/grid';
 
 const PageWrapper = styled('div')({
     margin: 'auto',
-    paddingLeft: 4,
-    paddingRight: 4,
-    [mobileLandscape]: {
-        paddingLeft: 24,
-        paddingRight: 24,
-    },
     [tablet]: {
-        maxWidth: '740px',
+        maxWidth: calculateWidth('tablet'),
     },
     [desktop]: {
-        maxWidth: '980px',
+        maxWidth: calculateWidth('desktop'),
     },
     [leftCol]: {
-        maxWidth: '1140px',
+        maxWidth: calculateWidth('leftCol'),
     },
     [wide]: {
-        maxWidth: '1300px',
+        maxWidth: calculateWidth('wide'),
     },
 });
 

--- a/src/pages/Article.js
+++ b/src/pages/Article.js
@@ -8,6 +8,7 @@ import { connect } from 'unistore/preact';
 import { textEgyptian, headline } from 'pasteup/fonts';
 import palette from 'pasteup/palette';
 import { clearFix } from 'pasteup/mixins';
+import { Grid, Row, Col } from 'pasteup/grid';
 
 import MostViewed from 'components/MostViewed';
 import Header from 'components/Header';
@@ -92,17 +93,24 @@ const SeriesLabel = styled(SectionLabel)({
 export default connect('content')(({ content }) => (
     <article>
         <Header />
-        <Labels>
-            <SectionLabel>The NSA files</SectionLabel>
-            <SeriesLabel>Glenn Greenwald on security and liberty</SeriesLabel>
-        </Labels>
-        <Headline>{content.headline}</Headline>
-        <Standfirst
-            dangerouslySetInnerHTML={{
-                __html: content.standfirst,
-            }}
-        />
-
+        <Grid>
+            <Row>
+                <Col wide={4} leftCol={4}>
+                    <Labels>
+                        <SectionLabel>The NSA files</SectionLabel>
+                        <SeriesLabel>Glenn Greenwald on security and liberty</SeriesLabel>
+                    </Labels>
+                </Col>
+                <Col wide={12} leftCol={10}>
+                    <Headline>{content.headline}</Headline>
+                    <Standfirst
+                        dangerouslySetInnerHTML={{
+                            __html: content.standfirst,
+                        }}
+                    />
+                </Col>
+            </Row>
+        </Grid>
         <div
             dangerouslySetInnerHTML={{
                 __html: content.main,

--- a/src/pages/Article.js
+++ b/src/pages/Article.js
@@ -8,7 +8,7 @@ import { connect } from 'unistore/preact';
 import { textEgyptian, headline } from 'pasteup/fonts';
 import palette from 'pasteup/palette';
 import { clearFix } from 'pasteup/mixins';
-import { Row, Col } from 'pasteup/grid';
+import { Row, Cols } from 'pasteup/grid';
 
 import MostViewed from 'components/MostViewed';
 import Header from 'components/Header';
@@ -94,22 +94,22 @@ export default connect('content')(({ content }) => (
     <article>
         <Header />
         <Row>
-            <Col wide={4} leftCol={4}>
+            <Cols wide={4} leftCol={4}>
                 <Labels>
                     <SectionLabel>The NSA files</SectionLabel>
                     <SeriesLabel>
                         Glenn Greenwald on security and liberty
                     </SeriesLabel>
                 </Labels>
-            </Col>
-            <Col wide={12} leftCol={10}>
+            </Cols>
+            <Cols wide={12} leftCol={10}>
                 <Headline>{content.headline}</Headline>
                 <Standfirst
                     dangerouslySetInnerHTML={{
                         __html: content.standfirst,
                     }}
                 />
-            </Col>
+            </Cols>
         </Row>
         <div
             dangerouslySetInnerHTML={{

--- a/src/pages/Article.js
+++ b/src/pages/Article.js
@@ -8,7 +8,7 @@ import { connect } from 'unistore/preact';
 import { textEgyptian, headline } from 'pasteup/fonts';
 import palette from 'pasteup/palette';
 import { clearFix } from 'pasteup/mixins';
-import { Grid, Row, Col } from 'pasteup/grid';
+import { Row, Col } from 'pasteup/grid';
 
 import MostViewed from 'components/MostViewed';
 import Header from 'components/Header';
@@ -93,26 +93,24 @@ const SeriesLabel = styled(SectionLabel)({
 export default connect('content')(({ content }) => (
     <article>
         <Header />
-        <Grid>
-            <Row>
-                <Col wide={4} leftCol={4}>
-                    <Labels>
-                        <SectionLabel>The NSA files</SectionLabel>
-                        <SeriesLabel>
-                            Glenn Greenwald on security and liberty
-                        </SeriesLabel>
-                    </Labels>
-                </Col>
-                <Col wide={12} leftCol={10}>
-                    <Headline>{content.headline}</Headline>
-                    <Standfirst
-                        dangerouslySetInnerHTML={{
-                            __html: content.standfirst,
-                        }}
-                    />
-                </Col>
-            </Row>
-        </Grid>
+        <Row>
+            <Col wide={4} leftCol={4}>
+                <Labels>
+                    <SectionLabel>The NSA files</SectionLabel>
+                    <SeriesLabel>
+                        Glenn Greenwald on security and liberty
+                    </SeriesLabel>
+                </Labels>
+            </Col>
+            <Col wide={12} leftCol={10}>
+                <Headline>{content.headline}</Headline>
+                <Standfirst
+                    dangerouslySetInnerHTML={{
+                        __html: content.standfirst,
+                    }}
+                />
+            </Col>
+        </Row>
         <div
             dangerouslySetInnerHTML={{
                 __html: content.main,

--- a/src/pages/Article.js
+++ b/src/pages/Article.js
@@ -94,7 +94,7 @@ export default connect('content')(({ content }) => (
     <article>
         <Header />
         <Row>
-            <Cols wide={4} leftCol={4}>
+            <Cols wide={4} leftCol={2}>
                 <Labels>
                     <SectionLabel>The NSA files</SectionLabel>
                     <SeriesLabel>
@@ -102,7 +102,7 @@ export default connect('content')(({ content }) => (
                     </SeriesLabel>
                 </Labels>
             </Cols>
-            <Cols wide={12} leftCol={10}>
+            <Cols wide={12} leftCol={12}>
                 <Headline>{content.headline}</Headline>
                 <Standfirst
                     dangerouslySetInnerHTML={{

--- a/src/pages/Article.js
+++ b/src/pages/Article.js
@@ -98,7 +98,9 @@ export default connect('content')(({ content }) => (
                 <Col wide={4} leftCol={4}>
                     <Labels>
                         <SectionLabel>The NSA files</SectionLabel>
-                        <SeriesLabel>Glenn Greenwald on security and liberty</SeriesLabel>
+                        <SeriesLabel>
+                            Glenn Greenwald on security and liberty
+                        </SeriesLabel>
                     </Labels>
                 </Col>
                 <Col wide={12} leftCol={10}>

--- a/src/pasteup/breakpoints.js
+++ b/src/pasteup/breakpoints.js
@@ -136,4 +136,5 @@ export const from = {
             wide: minWidthMaxWidth(breakpoints.leftCol, breakpoints.wide),
         },
     },
+    wide: minWidth(breakpoints.wide),
 };

--- a/src/pasteup/grid.js
+++ b/src/pasteup/grid.js
@@ -1,4 +1,4 @@
-import {Component} from 'preact';
+// @flow
 import styled from 'preact-emotion';
 import {
     tablet as tabletMq,
@@ -40,12 +40,13 @@ const breakpointMqs = {
 const gridStyles = (breakpoint, columnCount) => ({
     [breakpointMqs[breakpoint]]: {
         float: 'left',
-        width: (columnCount * columns[breakpoint].width) +
-            ((columnCount - 1) * columns[breakpoint].gutter),
+        width:
+            columnCount * columns[breakpoint].width +
+            (columnCount - 1) * columns[breakpoint].gutter,
         paddingRight: columns[breakpoint].gutter,
         ':last-of-type': {
             paddingRight: 0,
-        }
+        },
     },
 });
 
@@ -65,51 +66,10 @@ const ColStyled = styled('div')(({ tablet, desktop, leftCol, wide }) => {
     };
 });
 
-
-export class Grid extends Component {
-    constructor(props) {
-        super(props);
-    }
-
-    render() {
-        return (
-            <GridStyled>
-                {this.props.children}
-            </GridStyled>
-        );
-    }
-}
-
-export class Row extends Component {
-    constructor(props) {
-        super(props);
-    }
-
-    render() {
-        return (
-            <RowStyled>
-                {this.props.children}
-            </RowStyled>
-        );
-    }
-}
-
-export class Col extends Component {
-    constructor(props) {
-        super(props);
-    }
-
-    render() {
-        return (
-            <ColStyled
-                tablet={this.props.tablet}
-                desktop={this.props.desktop}
-                leftCol={this.props.leftCol}
-                wide={this.props.wide}
-            >
-                {this.props.children}
-            </ColStyled>
-        );
-    }
-
-}
+export const Grid = ({ children }) => <GridStyled>{children}</GridStyled>;
+export const Row = ({ children }) => <RowStyled>{children}</RowStyled>;
+export const Col = ({ tablet, desktop, leftCol, wide, children }) => (
+    <ColStyled tablet={tablet} desktop={desktop} leftCol={leftCol} wide={wide}>
+        {children}
+    </ColStyled>
+);

--- a/src/pasteup/grid.js
+++ b/src/pasteup/grid.js
@@ -51,7 +51,7 @@ const gridStyles = (breakpoint, columnCount) => ({
 });
 
 const RowStyled = styled('div')();
-const ColStyled = styled('div')(({ tablet, desktop, leftCol, wide }) => {
+const ColsStyled = styled('div')(({ tablet, desktop, leftCol, wide }) => {
     const tabletStyles = tablet ? gridStyles('tablet', tablet) : {};
     const desktopStyles = desktop ? gridStyles('desktop', desktop) : {};
     const leftColStyles = leftCol ? gridStyles('leftCol', leftCol) : {};
@@ -66,8 +66,8 @@ const ColStyled = styled('div')(({ tablet, desktop, leftCol, wide }) => {
 });
 
 export const Row = ({ children }) => <RowStyled>{children}</RowStyled>;
-export const Col = ({ tablet, desktop, leftCol, wide, children }) => (
-    <ColStyled tablet={tablet} desktop={desktop} leftCol={leftCol} wide={wide}>
+export const Cols = ({ tablet, desktop, leftCol, wide, children }) => (
+    <ColsStyled tablet={tablet} desktop={desktop} leftCol={leftCol} wide={wide}>
         {children}
-    </ColStyled>
+    </ColsStyled>
 );

--- a/src/pasteup/grid.js
+++ b/src/pasteup/grid.js
@@ -42,8 +42,10 @@ export const calculateWidth = (breakpoint, colspan) => {
         colspanOrMax = columns[breakpoint].max;
     }
 
-    return colspanOrMax * columns[breakpoint].width + (colspanOrMax - 1) * gutter;
-}
+    return (
+        colspanOrMax * columns[breakpoint].width + (colspanOrMax - 1) * gutter
+    );
+};
 
 const gridStyles = (breakpoint, [colspan]) => ({
     [breakpointMqs[breakpoint]]: {

--- a/src/pasteup/grid.js
+++ b/src/pasteup/grid.js
@@ -35,13 +35,20 @@ const breakpointMqs = {
     wide: wideMq,
 };
 
-const width = (breakpoint, colspan) =>
-    colspan * columns[breakpoint].width + colspan * gutter;
+export const calculateWidth = (breakpoint, colspan) => {
+    let colspanOrMax = colspan;
+
+    if (!colspanOrMax) {
+        colspanOrMax = columns[breakpoint].max;
+    }
+
+    return colspanOrMax * columns[breakpoint].width + (colspanOrMax - 1) * gutter;
+}
 
 const gridStyles = (breakpoint, [colspan]) => ({
     [breakpointMqs[breakpoint]]: {
         float: 'left',
-        width: width(breakpoint, colspan),
+        width: calculateWidth(breakpoint, colspan) + gutter,
         paddingLeft: gutter,
     },
 });

--- a/src/pasteup/grid.js
+++ b/src/pasteup/grid.js
@@ -1,0 +1,111 @@
+import {Component} from 'preact';
+import styled from 'preact-emotion';
+import {
+    leftCol as leftColMq,
+    wide as wideMq,
+} from './breakpoints';
+
+const columns = {
+    tablet: {
+        max: 12,
+        width: 40,
+        gutter: 20,
+    },
+    desktop: {
+        max: 12,
+        width: 60,
+        gutter: 20,
+    },
+    leftCol: {
+        max: 14,
+        width: 60,
+        gutter: 20,
+    },
+    wide: {
+        max: 16,
+        width: 60,
+        gutter: 20,
+    },
+};
+
+const GridStyled = styled('div')();
+const RowStyled = styled('div')();
+const ColStyled = styled('div')(({ wide, leftCol }) => {
+    console.log(wide)
+    const leftColStyles = leftCol ? {
+        [leftColMq]: {
+            float: 'left',
+            width: (leftCol * columns.leftCol.width) +
+            ((leftCol - 1) * columns.leftCol.gutter),
+            paddingRight: columns.leftCol.gutter,
+            ':last-of-type': {
+                paddingRight: 0,
+            }
+        },
+    } : {};
+    const wideStyles = wide ? {
+        [wideMq]: {
+            float: 'left',
+            width: (wide * columns.wide.width) +
+                ((wide - 1) * columns.wide.gutter),
+            paddingRight: columns.wide.gutter,
+            ':last-of-type': {
+                paddingRight: 0,
+            }
+        },
+    } : {};
+
+    const styles = {
+        ...leftColStyles,
+        ...wideStyles,
+    };
+
+    return styles;
+});
+
+
+export class Grid extends Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        return (
+            <GridStyled>
+                {this.props.children}
+            </GridStyled>
+        );
+    }
+}
+
+export class Row extends Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        return (
+            <RowStyled>
+                {this.props.children}
+            </RowStyled>
+        );
+    }
+}
+
+export class Col extends Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        return (
+            <ColStyled
+                wide={this.props.wide}
+                leftCol={this.props.leftCol}
+            >
+                {this.props.children}
+            </ColStyled>
+        );
+    }
+
+}

--- a/src/pasteup/grid.js
+++ b/src/pasteup/grid.js
@@ -1,6 +1,8 @@
 import {Component} from 'preact';
 import styled from 'preact-emotion';
 import {
+    tablet as tabletMq,
+    desktop as desktopMq,
     leftCol as leftColMq,
     wide as wideMq,
 } from './breakpoints';
@@ -28,39 +30,39 @@ const columns = {
     },
 };
 
+const breakpointMqs = {
+    tablet: tabletMq,
+    desktop: desktopMq,
+    leftCol: leftColMq,
+    wide: wideMq,
+};
+
+const gridStyles = (breakpoint, columnCount) => ({
+    [breakpointMqs[breakpoint]]: {
+        float: 'left',
+        width: (columnCount * columns[breakpoint].width) +
+            ((columnCount - 1) * columns[breakpoint].gutter),
+        paddingRight: columns[breakpoint].gutter,
+        ':last-of-type': {
+            paddingRight: 0,
+        }
+    },
+});
+
 const GridStyled = styled('div')();
 const RowStyled = styled('div')();
-const ColStyled = styled('div')(({ wide, leftCol }) => {
-    console.log(wide)
-    const leftColStyles = leftCol ? {
-        [leftColMq]: {
-            float: 'left',
-            width: (leftCol * columns.leftCol.width) +
-            ((leftCol - 1) * columns.leftCol.gutter),
-            paddingRight: columns.leftCol.gutter,
-            ':last-of-type': {
-                paddingRight: 0,
-            }
-        },
-    } : {};
-    const wideStyles = wide ? {
-        [wideMq]: {
-            float: 'left',
-            width: (wide * columns.wide.width) +
-                ((wide - 1) * columns.wide.gutter),
-            paddingRight: columns.wide.gutter,
-            ':last-of-type': {
-                paddingRight: 0,
-            }
-        },
-    } : {};
+const ColStyled = styled('div')(({ tablet, desktop, leftCol, wide }) => {
+    const tabletStyles = tablet ? gridStyles('tablet', tablet) : {};
+    const desktopStyles = desktop ? gridStyles('desktop', desktop) : {};
+    const leftColStyles = leftCol ? gridStyles('leftCol', leftCol) : {};
+    const wideStyles = wide ? gridStyles('wide', wide) : {};
 
-    const styles = {
+    return {
+        ...tabletStyles,
+        ...desktopStyles,
         ...leftColStyles,
         ...wideStyles,
     };
-
-    return styles;
 });
 
 
@@ -100,8 +102,10 @@ export class Col extends Component {
     render() {
         return (
             <ColStyled
-                wide={this.props.wide}
+                tablet={this.props.tablet}
+                desktop={this.props.desktop}
                 leftCol={this.props.leftCol}
+                wide={this.props.wide}
             >
                 {this.props.children}
             </ColStyled>

--- a/src/pasteup/grid.js
+++ b/src/pasteup/grid.js
@@ -50,7 +50,6 @@ const gridStyles = (breakpoint, columnCount) => ({
     },
 });
 
-const GridStyled = styled('div')();
 const RowStyled = styled('div')();
 const ColStyled = styled('div')(({ tablet, desktop, leftCol, wide }) => {
     const tabletStyles = tablet ? gridStyles('tablet', tablet) : {};
@@ -66,7 +65,6 @@ const ColStyled = styled('div')(({ tablet, desktop, leftCol, wide }) => {
     };
 });
 
-export const Grid = ({ children }) => <GridStyled>{children}</GridStyled>;
 export const Row = ({ children }) => <RowStyled>{children}</RowStyled>;
 export const Col = ({ tablet, desktop, leftCol, wide, children }) => (
     <ColStyled tablet={tablet} desktop={desktop} leftCol={leftCol} wide={wide}>

--- a/src/pasteup/grid.js
+++ b/src/pasteup/grid.js
@@ -7,26 +7,23 @@ import {
     wide as wideMq,
 } from './breakpoints';
 
+const gutter = 20;
 const columns = {
     tablet: {
         max: 12,
         width: 40,
-        gutter: 20,
     },
     desktop: {
         max: 12,
         width: 60,
-        gutter: 20,
     },
     leftCol: {
         max: 14,
         width: 60,
-        gutter: 20,
     },
     wide: {
         max: 16,
         width: 60,
-        gutter: 20,
     },
 };
 
@@ -42,8 +39,8 @@ const gridStyles = (breakpoint, columnCount) => ({
         float: 'left',
         width:
             columnCount * columns[breakpoint].width +
-            (columnCount - 1) * columns[breakpoint].gutter,
-        paddingRight: columns[breakpoint].gutter,
+            (columnCount - 1) * gutter,
+        paddingRight: gutter,
         ':last-of-type': {
             paddingRight: 0,
         },

--- a/src/pasteup/grid.js
+++ b/src/pasteup/grid.js
@@ -40,14 +40,13 @@ const gridStyles = (breakpoint, columnCount) => ({
         width:
             columnCount * columns[breakpoint].width +
             (columnCount - 1) * gutter,
-        paddingRight: gutter,
-        ':last-of-type': {
-            paddingRight: 0,
-        },
+        paddingLeft: gutter,
     },
 });
 
-const RowStyled = styled('div')();
+const RowStyled = styled('div')({
+    marginLeft: -gutter,
+});
 const ColsStyled = styled('div')(({ tablet, desktop, leftCol, wide }) => {
     const tabletStyles = tablet ? gridStyles('tablet', tablet) : {};
     const desktopStyles = desktop ? gridStyles('desktop', desktop) : {};

--- a/src/pasteup/grid.js
+++ b/src/pasteup/grid.js
@@ -6,6 +6,8 @@ import {
     leftCol as leftColMq,
     wide as wideMq,
 } from './breakpoints';
+import { clearFix } from './mixins';
+
 
 const gutter = 20;
 const columns = {
@@ -45,6 +47,7 @@ const gridStyles = (breakpoint, columnCount) => ({
 });
 
 const RowStyled = styled('div')({
+    ...clearFix,
     marginLeft: -gutter,
 });
 const ColsStyled = styled('div')(({ tablet, desktop, leftCol, wide }) => {

--- a/src/pasteup/grid.js
+++ b/src/pasteup/grid.js
@@ -8,7 +8,6 @@ import {
 } from './breakpoints';
 import { clearFix } from './mixins';
 
-
 const gutter = 20;
 const columns = {
     tablet: {
@@ -36,12 +35,13 @@ const breakpointMqs = {
     wide: wideMq,
 };
 
-const gridStyles = (breakpoint, columnCount) => ({
+const width = (breakpoint, colspan) =>
+    colspan * columns[breakpoint].width + colspan * gutter;
+
+const gridStyles = (breakpoint, [colspan]) => ({
     [breakpointMqs[breakpoint]]: {
         float: 'left',
-        width:
-            columnCount * columns[breakpoint].width +
-            (columnCount - 1) * gutter,
+        width: width(breakpoint, colspan),
         paddingLeft: gutter,
     },
 });
@@ -51,10 +51,10 @@ const RowStyled = styled('div')({
     marginLeft: -gutter,
 });
 const ColsStyled = styled('div')(({ tablet, desktop, leftCol, wide }) => {
-    const tabletStyles = tablet ? gridStyles('tablet', tablet) : {};
-    const desktopStyles = desktop ? gridStyles('desktop', desktop) : {};
-    const leftColStyles = leftCol ? gridStyles('leftCol', leftCol) : {};
-    const wideStyles = wide ? gridStyles('wide', wide) : {};
+    const tabletStyles = gridStyles('tablet', tablet);
+    const desktopStyles = gridStyles('desktop', desktop);
+    const leftColStyles = gridStyles('leftCol', leftCol);
+    const wideStyles = gridStyles('wide', wide);
 
     return {
         ...tabletStyles,
@@ -64,9 +64,32 @@ const ColsStyled = styled('div')(({ tablet, desktop, leftCol, wide }) => {
     };
 });
 
+const normaliseProps = prop => {
+    if (Array.isArray(prop)) {
+        if (prop.length === 1) {
+            return [...prop, {}];
+        }
+
+        return prop;
+    } else if (typeof prop === 'number') {
+        return [prop, {}];
+    }
+};
+
 export const Row = ({ children }) => <RowStyled>{children}</RowStyled>;
-export const Cols = ({ tablet, desktop, leftCol, wide, children }) => (
-    <ColsStyled tablet={tablet} desktop={desktop} leftCol={leftCol} wide={wide}>
+export const Cols = ({
+    tablet = [columns.tablet.max, {}],
+    desktop = [columns.desktop.max, {}],
+    leftCol = [columns.leftCol.max, {}],
+    wide = [columns.wide.max, {}],
+    children,
+}) => (
+    <ColsStyled
+        tablet={normaliseProps(tablet)}
+        desktop={normaliseProps(desktop)}
+        leftCol={normaliseProps(leftCol)}
+        wide={normaliseProps(wide)}
+    >
         {children}
     </ColsStyled>
 );


### PR DESCRIPTION
## What does this change?

Adds the first pass at a grid system. Column numbers, column and gutter widths based on [our design guide](https://design.gutools.co.uk/#grids-spacing)

### So far functionality

Allows you to define a grid layout like this:

```jsx
<Grid>
  <Row>
    <Col wide={4} leftCol={4} desktop={4} tablet={3}>
      <Component.a/>
    </Col>
    <Col wide={12} leftCol={10} desktop={8} tablet={9}>
      <Component.b/>
    </Col>
  </Row>
</Grid>
```

Only supports the following breakpoints:

- wide
- leftCol
- desktop
- tablet

If any of these breakpoints is omitted, it is assumed the contents will stretch to 100% of the width of the container at that breakpoint.

Mobile breakpoints and tweaks are intended to be fluid and hence not supported here.

### Todo

- [ ] Support starting component at a specific column
- [ ] For cols that start at a specific column, support an `auto` width
- [ ] Prevent styling of Grid helper components
- [ ] Enforce acceptable number of columns at compile time
- [ ] Types
- [x] Clearfix `<Row>` components

## Why?

For consistent design