### PR TITLE
Such grid, much inset

### DIFF
--- a/src/pages/Article.js
+++ b/src/pages/Article.js
@@ -94,7 +94,7 @@ export default connect('content')(({ content }) => (
     <article>
         <Header />
         <Row>
-            <Cols wide={4} leftCol={2}>
+            <Cols wide={3} leftCol={2}>
                 <Labels>
                     <SectionLabel>The NSA files</SectionLabel>
                     <SeriesLabel>
@@ -102,7 +102,7 @@ export default connect('content')(({ content }) => (
                     </SeriesLabel>
                 </Labels>
             </Cols>
-            <Cols wide={12} leftCol={12}>
+            <Cols wide={[12, { inset: 1 }]} leftCol={12}>
                 <Headline>{content.headline}</Headline>
                 <Standfirst
                     dangerouslySetInnerHTML={{

--- a/src/pasteup/grid.js
+++ b/src/pasteup/grid.js
@@ -47,11 +47,14 @@ export const calculateWidth = (breakpoint, colspan) => {
     );
 };
 
-const gridStyles = (breakpoint, [colspan]) => ({
+const gridStyles = (breakpoint, [colspan, options]) => ({
     [breakpointMqs[breakpoint]]: {
         float: 'left',
         width: calculateWidth(breakpoint, colspan) + gutter,
         paddingLeft: gutter,
+        marginLeft: options.inset
+            ? calculateWidth(breakpoint, options.inset) + gutter
+            : 0,
     },
 });
 


### PR DESCRIPTION
## What does this change?

Grid Cols props accept a second argument of options. Passing an `inset` property allows us to inset a component by the specified number of columns.

```jsx
<Row>
  <Cols wide={3}> { // width is 3 columns above wide breakpoint }
    <Component.a />
  </Cols>
  <Cols wide={[12, { inset: 1 }]}> { // width is 12 columns above wide breakpoint, with one column of left margin }
    <Component.b />
  </Cols>
</Row>
```