### PR TITLE
Support auto width

### DIFF
--- a/src/pages/Article.js
+++ b/src/pages/Article.js
@@ -102,7 +102,7 @@ export default connect('content')(({ content }) => (
                     </SeriesLabel>
                 </Labels>
             </Cols>
-            <Cols wide={12} leftCol={12}>
+            <Cols wide={'auto'} leftCol={12}>
                 <Headline>{content.headline}</Headline>
                 <Standfirst
                     dangerouslySetInnerHTML={{

--- a/src/pasteup/grid.js
+++ b/src/pasteup/grid.js
@@ -47,17 +47,27 @@ export const calculateWidth = (breakpoint, colspan) => {
     );
 };
 
-const gridStyles = (breakpoint, [colspan]) => ({
-    [breakpointMqs[breakpoint]]: {
-        float: 'left',
-        width: calculateWidth(breakpoint, colspan) + gutter,
-        paddingLeft: gutter,
-    },
-});
+const gridStyles = (breakpoint, [colspan]) => {
+    let basis;
+
+    if (typeof colspan === 'number') {
+        basis = `${calculateWidth(breakpoint, colspan) + gutter}px`;
+    } else if (colspan === 'auto') {
+        basis = 'auto';
+    }
+
+    return {
+        [breakpointMqs[breakpoint]]: {
+            flex: `0 1 ${basis}`,
+            paddingLeft: gutter,
+        },
+    };
+};
 
 const RowStyled = styled('div')({
     ...clearFix,
     marginLeft: -gutter,
+    display: 'flex',
 });
 const ColsStyled = styled('div')(({ tablet, desktop, leftCol, wide }) => {
     const tabletStyles = gridStyles('tablet', tablet);
@@ -80,7 +90,7 @@ const normaliseProps = prop => {
         }
 
         return prop;
-    } else if (typeof prop === 'number') {
+    } else if (typeof prop === 'number' || typeof prop === 'string') {
         return [prop, {}];
     }
 };


### PR DESCRIPTION
## What does this change?

Automatic calculation of column width for one component in a Row

```jsx
<Row>
  <Cols wide={4}>
     <Component.a/>
  </Cols>
  <Cols wide={'auto'}>
     <Component.b/>
  </Cols>
</Row>
```

In order to support this property, we need to move from using `float`s to using `flex`. This entails a small drop in browser support.

## Why?

Better API