### PR TITLE
Grid: support inset

### DIFF
--- a/packages/guui/grid.js
+++ b/packages/guui/grid.js
@@ -47,11 +47,14 @@ export const calculateWidth = (breakpoint, colspan) => {
     );
 };
 
-const gridStyles = (breakpoint, [colspan]) => ({
+const gridStyles = (breakpoint, [colspan, options]) => ({
     [breakpointMqs[breakpoint]]: {
         float: 'left',
         width: calculateWidth(breakpoint, colspan) + gutter,
         paddingLeft: gutter,
+        marginLeft: options.inset
+            ? calculateWidth(breakpoint, options.inset) + gutter
+            : 0,
     },
 });
 


### PR DESCRIPTION
## What does this change?

Grid Cols props accept a second argument of options. Passing an `inset` property allows us to inset a component by the specified number of columns.

```jsx
<Row>
  <Cols wide={3}> { // width is 3 columns above wide breakpoint }
    <Component.a />
  </Cols>
  <Cols wide={[12, { inset: 1 }]}> { // width is 12 columns above wide breakpoint, with one column of left margin }
    <Component.b />
  </Cols>
</Row>
```

If you have two `Cols` side by side, can each of them specify an `inset` property?

```js
<Row>
  <Cols wide={[2, { inset: 2 }]}> 
    <Component.a />
  </Cols>
  <Cols wide={[2, { inset: 1 }]}>
    <Component.b />
  </Cols>
</Row>
```
YES! It would it look like □□■■□■■□□□□□□□□□

So the inset is the number of columns in from where it would naturally appear, rather than from  full left (column 0)
