### PR TITLE
Rejig document layout

### DIFF
--- a/sites/dotcom/components/Main.js
+++ b/sites/dotcom/components/Main.js
@@ -1,0 +1,28 @@
+// @flow
+import { styled } from '@guardian/guui';
+
+import {
+    mobileLandscape,
+    tablet,
+    desktop,
+    leftCol,
+    wide,
+} from '@guardian/pasteup/breakpoints';
+
+const Page = styled('main')({
+    margin: 'auto',
+    [tablet]: {
+        maxWidth: '740px',
+    },
+    [desktop]: {
+        maxWidth: '980px',
+    },
+    [leftCol]: {
+        maxWidth: '1140px',
+    },
+    [wide]: {
+        maxWidth: '1300px',
+    },
+});
+
+export default Page;

--- a/sites/dotcom/components/Page.js
+++ b/sites/dotcom/components/Page.js
@@ -9,26 +9,6 @@ import {
     wide,
 } from '@guardian/pasteup/breakpoints';
 
-const Page = styled('div')({
-    margin: 'auto',
-    paddingLeft: 4,
-    paddingRight: 4,
-    [mobileLandscape]: {
-        paddingLeft: 24,
-        paddingRight: 24,
-    },
-    [tablet]: {
-        maxWidth: '740px',
-    },
-    [desktop]: {
-        maxWidth: '980px',
-    },
-    [leftCol]: {
-        maxWidth: '1140px',
-    },
-    [wide]: {
-        maxWidth: '1300px',
-    },
-});
+const Page = styled('div')();
 
 export default Page;

--- a/sites/dotcom/pages/Article.js
+++ b/sites/dotcom/pages/Article.js
@@ -11,6 +11,7 @@ import palette from '@guardian/pasteup/palette';
 import { clearFix } from '@guardian/pasteup/mixins';
 
 import Page from '../components/Page';
+import Main from '../components/Main';
 import MostViewed from '../components/MostViewed';
 import Header from '../components/Header';
 import Epic from '../components/Epic';
@@ -93,51 +94,53 @@ const SeriesLabel = styled(SectionLabel)({
 
 export default connect('CAPI')(({ CAPI = {} }) => (
     <Page>
-        <article>
-            <Header />
-            <Row>
-                <Cols wide={4} leftCol={2}>
-                    <Labels>
-                        <SectionLabel>The NSA files</SectionLabel>
-                        <SeriesLabel>
-                            Glenn Greenwald on security and liberty
-                        </SeriesLabel>
-                    </Labels>
-                </Cols>
-                <Cols wide={12} leftCol={12}>
-                    <Headline>{CAPI.headline}</Headline>
-                    <Standfirst
-                        dangerouslySetInnerHTML={{
-                            __html: CAPI.standfirst,
-                        }}
-                    />
-                </Cols>
-            </Row>
-            <div
-                dangerouslySetInnerHTML={{
-                    __html: CAPI.main,
-                }}
-            />
-            <Body
-                dangerouslySetInnerHTML={{
-                    __html: CAPI.body,
-                }}
-            />
-            <MostViewed />
-            <Epic>
-                <strong>
-                    Unlike many news organisations, we haven’t put up a paywall
-                    – we want to keep our journalism as open as we can.
-                </strong>{' '}
-                The Guardian’s independent, investigative journalism takes a lot
-                of time, money and hard work to produce. But the revenue we get
-                from advertising is falling, so we increasingly need our readers
-                to fund us. If everyone who reads our reporting, who likes it,
-                helps fund it, our future would be much more secure.{' '}
-                <strong>
-                    Support The Guardian for just 17p a day or £5 a month.
-                </strong>
-            </Epic>
-        </article>
+        <Header />
+        <Main>
+            <article>
+                <Row>
+                    <Cols wide={3} leftCol={2}>
+                        <Labels>
+                            <SectionLabel>The NSA files</SectionLabel>
+                            <SeriesLabel>
+                                Glenn Greenwald on security and liberty
+                            </SeriesLabel>
+                        </Labels>
+                    </Cols>
+                    <Cols wide={13} leftCol={12}>
+                        <Headline>{CAPI.headline}</Headline>
+                        <Standfirst
+                            dangerouslySetInnerHTML={{
+                                __html: CAPI.standfirst,
+                            }}
+                        />
+                    </Cols>
+                </Row>
+                <div
+                    dangerouslySetInnerHTML={{
+                        __html: CAPI.main,
+                    }}
+                />
+                <Body
+                    dangerouslySetInnerHTML={{
+                        __html: CAPI.body,
+                    }}
+                />
+                <MostViewed />
+                <Epic>
+                    <strong>
+                        Unlike many news organisations, we haven’t put up a paywall
+                        – we want to keep our journalism as open as we can.
+                    </strong>{' '}
+                    The Guardian’s independent, investigative journalism takes a lot
+                    of time, money and hard work to produce. But the revenue we get
+                    from advertising is falling, so we increasingly need our readers
+                    to fund us. If everyone who reads our reporting, who likes it,
+                    helps fund it, our future would be much more secure.{' '}
+                    <strong>
+                        Support The Guardian for just 17p a day or £5 a month.
+                    </strong>
+                </Epic>
+            </article>
+        </Main>
     </Page>
 ));


### PR DESCRIPTION
## What does this change?

- Remove current styling from `Page`
- Introduce a `Main` component, a sibling of `Header`. This contains all the `max-width` styling previously found on `Page`
- Remove all padding from `Main`. This interferes with the grid system and isn't present in [the Design guidelines](https://design.gutools.co.uk/#grids-spacing)

## Why?

This pre-work is necessary to fix the grid system, but isn't part of implementing the grid system per se. Therefore I've extracted it for discussion if necessary.

The most important change is to extract the `Header` out of the `max-width` constraint specified by `Page`, to allow the background to stretch to 100% of the viewport width.

**Before**

![screen shot 2018-05-29 at 15 58 56](https://user-images.githubusercontent.com/5931528/40667114-44037812-6359-11e8-88b5-956f92ff7a0a.png)

**After**

![screen shot 2018-05-29 at 15 58 37](https://user-images.githubusercontent.com/5931528/40667125-472bd886-6359-11e8-9b50-b2628c09a25c.png)